### PR TITLE
Use regular expression to match more message template about rgy

### DIFF
--- a/zhong.py
+++ b/zhong.py
@@ -172,7 +172,7 @@ def fuq(bot,update):
     if text in welcome_msg or text in reply_msg:
         update.message.reply_text(random.choice(reply_msg))
 
-    if re.match("[亲,抱]*.*[rgy,饶耕宇].*[亲,抱,啪啪啪]*", text):
+    if re.match("[亲,抱]+.*[rgy,饶耕宇].*", text) or re.match(".*[rgy,饶耕宇].*[亲,抱,啪啪啪]+.*", text):
         if random.choice(range(2)) == 1:
             re_list = ["那么喜欢的话……钟钟就把rgy给你啦~",
                   "亲亲rgy",

--- a/zhong.py
+++ b/zhong.py
@@ -172,13 +172,13 @@ def fuq(bot,update):
     if text in welcome_msg or text in reply_msg:
         update.message.reply_text(random.choice(reply_msg))
 
-    if text == "亲亲rgy":
+    if re.match("[亲,抱]*.*[rgy,饶耕宇].*[亲,抱,啪啪啪]*", text):
         if random.choice(range(2)) == 1:
-            re = ["亲亲",
+            re_list = ["那么喜欢的话……钟钟就把rgy给你啦~",
                   "亲亲rgy",
                   "No gay, plz!",
                   "More gay, plz!"]
-            update.message.reply_text(random.choice(re))
+            update.message.reply_text(random.choice(re_list))
 
 def main():
     """Run bot."""


### PR DESCRIPTION
Bot in this version reply messages about rgy only when `input_msg == "亲亲rgy"`.
Consider a Chinese setence about kissing rgy, the word "亲亲" is either before or after word "rgy". And between this two words, there can be arbitrary number of words.
Therefore it's more interesting to use regular expression to match more message template.

:  )